### PR TITLE
remove update terms message on login

### DIFF
--- a/ccid-views/login.erb
+++ b/ccid-views/login.erb
@@ -14,13 +14,6 @@
 
     <h2 class="form-signin-heading">Please sign in</h2>
 
-  <% if not @authenticated %>
-  <div class="alert alert-info">
-  <strong>2018-05-25: We have updated our <a href="https://creativecommons.org/terms/">Terms of Service</a> and <a href="https://creativecommons.org/privacy/">Privacy Policy</a>.</strong><br />
-  Before continuing on our websites or using our services, please review.
-  </div>
-  <% end %>
-
     <input type="email" id="username" name="username" class="form-control" placeholder="Email address" required autofocus>
     <input type="password" name="password" class="form-control" placeholder="Password" required autocomplete="off">
     <input type="hidden" id="lt" name="lt" value="<%= escape_html @lt %>" />


### PR DESCRIPTION
## Fixes
Fixes creativecommons/tech-support#638
Fixes #9 

## Description
This PR removes the message before login because is no longer needed
![Screen Shot 2020-08-24 at 8 00 34 AM](https://user-images.githubusercontent.com/894708/91449182-ce05d700-e848-11ea-9cdd-11f3f0d7dc6e.png)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
